### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Jira's REST API using the `jira-python` library. This server integrates with Claude Desktop and other MCP clients, allowing you to interact with Jira using natural language commands.
 
+<a href="https://glama.ai/mcp/servers/@InfinitIQ-Tech/mcp-jira">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@InfinitIQ-Tech/mcp-jira/badge" alt="Jira Server MCP server" />
+</a>
+
 ## Features
 
 - Get all accessible Jira projects


### PR DESCRIPTION
This PR adds a badge for the [Jira MCP Server](https://glama.ai/mcp/servers/@InfinitIQ-Tech/mcp-jira) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@InfinitIQ-Tech/mcp-jira">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@InfinitIQ-Tech/mcp-jira/badge" alt="Jira Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an HTML badge linking to the MCP Jira server page on glama.ai near the top of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->